### PR TITLE
fix: Dockerfile の Node.js バージョンを 22 LTS に更新

### DIFF
--- a/downloader/Dockerfile
+++ b/downloader/Dockerfile
@@ -19,7 +19,7 @@ RUN cp echoprint-codegen /usr/local/bin/
 WORKDIR /build
 RUN rm -rf echoprint-codegen
 
-FROM node:20 AS runner
+FROM node:22 AS runner
 
 # hadolint ignore=DL3008
 RUN apt-get update && \

--- a/downloader/Dockerfile
+++ b/downloader/Dockerfile
@@ -19,7 +19,7 @@ RUN cp echoprint-codegen /usr/local/bin/
 WORKDIR /build
 RUN rm -rf echoprint-codegen
 
-FROM node:22 AS runner
+FROM node:24 AS runner
 
 # hadolint ignore=DL3008
 RUN apt-get update && \

--- a/viewer/Dockerfile
+++ b/viewer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20 AS builder
+FROM node:22 AS builder
 
 WORKDIR /build
 
@@ -13,7 +13,7 @@ COPY src src
 
 RUN yarn build
 
-FROM node:20 AS runner
+FROM node:22 AS runner
 
 WORKDIR /app
 

--- a/viewer/Dockerfile
+++ b/viewer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22 AS builder
+FROM node:24 AS builder
 
 WORKDIR /build
 
@@ -13,7 +13,7 @@ COPY src src
 
 RUN yarn build
 
-FROM node:22 AS runner
+FROM node:24 AS runner
 
 WORKDIR /app
 


### PR DESCRIPTION
## 概要

`rollup-plugin-visualizer@7.0.1` が Node.js >=22 を要求するようになったため、Docker イメージの Node.js バージョンを 20 から 24 (LTS) に更新します。

あわせて、`viewer/.node-version` および `downloader/.node-version` が Node.js 24.15.0 を指定しているため、Dockerfile のバージョンもそれに統一しました。

## 変更内容

- `viewer/Dockerfile`: builder ステージおよび runner ステージを `node:20` から `node:24` に更新
- `downloader/Dockerfile`: runner ステージを `node:20` から `node:24` に更新

## 背景

Renovate PR #2613 (lock file maintenance) および #2665 (update nuxt to v3.21.6) の Docker CI が以下のエラーで失敗していた。

```
error rollup-plugin-visualizer@7.0.1: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.20.2"
error Found incompatible module.
```

`rollup-plugin-visualizer@7.0.1` が `engines.node >= 22` を要求しているが、既存の Dockerfile では Node 20.20.2 が使用されていたため、`yarn install --frozen-lockfile` が失敗していた。

`viewer/.node-version` および `downloader/.node-version` はすでに Node.js 24.15.0 に設定されており、Dockerfile も同バージョンに統一することでローカル/CI と本番コンテナ間のバージョン不一致を解消している。

## 備考

過去に Node 21 から Node 20 にダウングレードした経緯 (#583 / issue #582) があり、その際は `echoprint-codegen` のエラーが原因だった。今回 Node 24 での Docker ビルド CI が正常に通過したことを確認済み。

🤖 Generated with [Claude Code](https://claude.ai/code)