### PR TITLE
fix: TypeScript v6 対応のため downloader の tsconfig.json を更新

### DIFF
--- a/downloader/tsconfig.json
+++ b/downloader/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "moduleResolution": "Node",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "lib": ["ESNext", "ESNext.AsyncIterable", "DOM"],
+    "rootDir": "./src",
     "outDir": "./dist",
     "removeComments": true,
     "esModuleInterop": true,
@@ -20,11 +22,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
-    "newLine": "LF",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "newLine": "LF"
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## 概要

Renovate PR #2617 (`chore(deps): update dependency typescript to v6`) 適用時に CI が失敗する問題を修正します。

## 変更内容

`downloader/tsconfig.json` を TypeScript v5/v6 両方で動作するように更新しました。

### 修正した問題

TypeScript v6 で以下のエラーが発生していました：

- `TS5107: 'moduleResolution=node10' is deprecated — add "ignoreDeprecations": "6.0"`
- `TS5101: 'baseUrl' is deprecated — add "ignoreDeprecations": "6.0"`
- `TS5011: 'rootDir' must be explicitly set`

### 変更の詳細

| 変更項目 | 変更前 | 変更後 | 理由 |
|---|---|---|---|
| `moduleResolution` | `"Node"` (deprecated) | `"Node16"` | `Node` は TypeScript v6 で deprecated |
| `module` | (未設定) | `"Node16"` | `moduleResolution: Node16` に対して必須 |
| `rootDir` | (未設定) | `"./src"` | TypeScript v6 で明示的な設定が必須 |
| `baseUrl` | `"."` | (削除) | TypeScript v6 で deprecated、かつ `paths` エイリアスが未使用のため不要 |
| `paths` | `{ "@/*": ["./src/*"] }` | (削除) | ソースコード内で `@/` エイリアスが一切使用されていないため不要 |

### `ignoreDeprecations` を使わない理由

`"ignoreDeprecations": "6.0"` は TypeScript v6 でのみ有効な値で、現在の v5.x では無効です。そのため、deprecated オプションを根本的に置き換えることで TypeScript v5/v6 の両バージョンで CI が通るようにしました。

### viewer/tsconfig.json について

`viewer/tsconfig.json` は Nuxt が自動生成する `.nuxt/tsconfig.json` を extends しているだけのため、変更不要です。

## 動作確認

```
$ npx tsc --noEmit  # TypeScript v5.9.3
✓ エラーなし

$ yarn compile      # tsc -p .
✓ エラーなし
```

## 関連

- Renovate PR #2617: `chore(deps): update dependency typescript to v6`