### PR TITLE
feat(downloader): プレイリストへの新規動画追加を高頻度に検出できるようにする(検出ループの分離)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ services:
     environment:
       - TZ=<Timezone>
       - BASE_URL=http://<ServerHost>:<ViewerPort>
+      # - DETECTION_INTERVAL_SECONDS=300 # Optional: interval (seconds) for detecting new videos in the playlist. Default: 300 (5 minutes)
+      # - PIPELINE_INTERVAL_SECONDS=3600 # Optional: interval (seconds) for the full download/processing pipeline. Default: 3600 (1 hour)
     volumes:
       - type: bind
         source: ./data

--- a/downloader/entrypoint.sh
+++ b/downloader/entrypoint.sh
@@ -4,8 +4,6 @@ while :
 do
   yarn build || true
 
-  echo "Waiting..."
-
-  # wait 1 hour
-  sleep 3600
+  echo "Process exited. Restarting in 10 seconds..."
+  sleep 10
 done

--- a/downloader/src/main.ts
+++ b/downloader/src/main.ts
@@ -377,7 +377,7 @@ let isHeavyRunning = false
 let heavyTimeoutHandle: NodeJS.Timeout | undefined
 
 /**
- * 重いダウンロード・変換・後処理パイプラインを1回実行する
+ * 重いダウンロード・変換・後処理パイプラインを 1 回実行する
  *
  * 既にパイプラインが実行中の場合は何もせず終了する(多重実行の防止)。
  * 実行完了後は、成否に関わらず次回の定期実行タイマーを再設定する。
@@ -476,16 +476,19 @@ async function runHeavyPipeline(reason: string) {
 }
 
 /**
- * プレイリストの新規動画IDを高頻度に検出するループを1回実行する
+ * プレイリストの新規動画 ID を高頻度に検出するループを 1 回実行する
  *
- * 新規IDを検出した場合、重いパイプラインを即座にトリガーする。
+ * 新規 ID を検出した場合、重いパイプラインを即座にトリガーする。
+ * 重いパイプラインの完了は待たず、検出ループ自体は直ちに次回をスケジュールする
+ * (待ってしまうと、検出自身がトリガーした実行中は高頻度検出が止まってしまうため)。
  * 完了後は、成否に関わらず次回の検出ループをスケジュールする。
  */
-async function runDetectionLoop() {
+function runDetectionLoop() {
   const logger = Logger.configure('runDetectionLoop')
 
   try {
     const config = getConfig()
+    removeCacheDir()
     const ids = getPlaylistVideoIds(config.playlistId)
     const newIds = ids.filter((id) => !lastKnownIds.includes(id))
     lastKnownIds = ids
@@ -494,15 +497,15 @@ async function runDetectionLoop() {
       logger.info(
         `🆕 Detected ${newIds.length} new video(s): ${newIds.join(', ')}`,
       )
-      await runHeavyPipeline('new-videos-detected')
+      ;(async () => {
+        await runHeavyPipeline('new-videos-detected')
+      })()
     }
   } catch (error) {
     logger.error('Failed to run detection loop', error as Error)
   } finally {
     setTimeout(() => {
-      ;(async () => {
-        await runDetectionLoop()
-      })()
+      runDetectionLoop()
     }, DETECTION_INTERVAL_SECONDS * 1000)
   }
 }
@@ -514,16 +517,15 @@ async function main() {
   logger.info(`  - Detection interval (sec): ${DETECTION_INTERVAL_SECONDS}`)
   logger.info(`  - Pipeline interval (sec): ${PIPELINE_INTERVAL_SECONDS}`)
 
-  // 起動時に現在のID一覧を取得してベースラインとし、直後に重い処理を1回実行する
+  // 起動時に現在の ID 一覧を取得してベースラインとし、直後に重い処理を 1 回実行する
   const config = getConfig()
+  removeCacheDir()
   lastKnownIds = getPlaylistVideoIds(config.playlistId)
   await runHeavyPipeline('startup')
 
   // 常駐ループを開始する(このプロセスは終了しない)
   setTimeout(() => {
-    ;(async () => {
-      await runDetectionLoop()
-    })()
+    runDetectionLoop()
   }, DETECTION_INTERVAL_SECONDS * 1000)
 }
 

--- a/downloader/src/main.ts
+++ b/downloader/src/main.ts
@@ -365,68 +365,166 @@ function createPlaylistFile() {
   fs.writeFileSync('/data/tracks/YouTubeDownloadeds.m3u8', playlist)
 }
 
-async function main() {
-  const logger = Logger.configure('main')
-  const config = getConfig()
-  const playlistId = config.playlistId
+const DETECTION_INTERVAL_SECONDS = process.env.DETECTION_INTERVAL_SECONDS
+  ? Number.parseInt(process.env.DETECTION_INTERVAL_SECONDS, 10)
+  : 300
+const PIPELINE_INTERVAL_SECONDS = process.env.PIPELINE_INTERVAL_SECONDS
+  ? Number.parseInt(process.env.PIPELINE_INTERVAL_SECONDS, 10)
+  : 3600
 
-  const runnerCountForDownload = process.env.RUNNER_COUNT_FOR_DOWNLOAD
-    ? Number.parseInt(process.env.RUNNER_COUNT_FOR_DOWNLOAD, 10)
-    : 3
-  const runnerCountForProcessing = process.env.RUNNER_COUNT_FOR_PROCESSING
-    ? Number.parseInt(process.env.RUNNER_COUNT_FOR_PROCESSING, 10)
-    : 3
+let lastKnownIds: string[] = []
+let isHeavyRunning = false
+let heavyTimeoutHandle: NodeJS.Timeout | undefined
 
-  logger.info('📝 Configuration:')
-  logger.info(`  - Playlist ID: ${playlistId}`)
-  logger.info(`  - Discord: ${config.discord ? 'Enabled' : 'Disabled'}`)
-  logger.info(
-    `  - Using normalize volume app: ${process.env.NORMALIZE_VOLUME_APP ?? 'mp3gain'}`,
-  )
-  logger.info(`  - Runner count for download: ${runnerCountForDownload}`)
-  logger.info(`  - Runner count for processing: ${runnerCountForProcessing}`)
+/**
+ * 重いダウンロード・変換・後処理パイプラインを1回実行する
+ *
+ * 既にパイプラインが実行中の場合は何もせず終了する(多重実行の防止)。
+ * 実行完了後は、成否に関わらず次回の定期実行タイマーを再設定する。
+ *
+ * @param reason 実行理由(ログ出力用。例: 'startup' | 'scheduled' | 'new-videos-detected')
+ */
+async function runHeavyPipeline(reason: string) {
+  const logger = Logger.configure('runHeavyPipeline')
 
-  logger.info('📁 Recreating directories...')
-  recreateDirectories()
-
-  logger.info('🗑️ Deleting yt-dlp cache...')
-  removeCacheDir()
-
-  logger.info(`📚 Getting playlist videos for ${playlistId}`)
-  const ids = getPlaylistVideoIds(playlistId)
-
-  logger.info(`🎥 Found ${ids.length} videos. Downloading...`)
-
-  // プレイリスト動画をダウンロード
-  const successfullyDownloadedIds = await new ParallelDownloadVideo(ids).runAll(
-    runnerCountForDownload,
-  )
-
-  logger.info(
-    `📥 Successfully downloaded ${successfullyDownloadedIds.length}/${ids.length} videos`,
-  )
-
-  if (successfullyDownloadedIds.length === 0) {
-    logger.warn(
-      '⚠️ No videos were successfully downloaded. Skipping processing.',
+  if (isHeavyRunning) {
+    logger.info(
+      `⏭️ Skipping heavy pipeline trigger (${reason}): already running`,
     )
     return
   }
 
-  // ダウンロードしたプレイリスト動画を処理
-  await new ParallelProcessVideo(successfullyDownloadedIds).runAll(
-    runnerCountForProcessing,
-  )
+  isHeavyRunning = true
+  if (heavyTimeoutHandle) {
+    clearTimeout(heavyTimeoutHandle)
+    heavyTimeoutHandle = undefined
+  }
 
-  // プレイリストにない音楽ファイルを削除
-  logger.info('🗑️ Deleting playlist removed tracks...')
-  deleteRemovedTracks(ids)
+  try {
+    logger.info(`🚀 Starting heavy pipeline (reason: ${reason})`)
 
-  // ダウンロードした音楽ファイルを元にプレイリストファイルを作成
-  logger.info('📝 Creating playlist file...')
-  createPlaylistFile()
+    const config = getConfig()
+    const playlistId = config.playlistId
 
-  logger.info('🎉 Successfully finished!')
+    const runnerCountForDownload = process.env.RUNNER_COUNT_FOR_DOWNLOAD
+      ? Number.parseInt(process.env.RUNNER_COUNT_FOR_DOWNLOAD, 10)
+      : 3
+    const runnerCountForProcessing = process.env.RUNNER_COUNT_FOR_PROCESSING
+      ? Number.parseInt(process.env.RUNNER_COUNT_FOR_PROCESSING, 10)
+      : 3
+
+    logger.info('📝 Configuration:')
+    logger.info(`  - Playlist ID: ${playlistId}`)
+    logger.info(`  - Discord: ${config.discord ? 'Enabled' : 'Disabled'}`)
+    logger.info(
+      `  - Using normalize volume app: ${process.env.NORMALIZE_VOLUME_APP ?? 'mp3gain'}`,
+    )
+    logger.info(`  - Runner count for download: ${runnerCountForDownload}`)
+    logger.info(`  - Runner count for processing: ${runnerCountForProcessing}`)
+
+    logger.info('📁 Recreating directories...')
+    recreateDirectories()
+
+    logger.info('🗑️ Deleting yt-dlp cache...')
+    removeCacheDir()
+
+    logger.info(`📚 Getting playlist videos for ${playlistId}`)
+    const ids = getPlaylistVideoIds(playlistId)
+
+    logger.info(`🎥 Found ${ids.length} videos. Downloading...`)
+
+    // プレイリスト動画をダウンロード
+    const successfullyDownloadedIds = await new ParallelDownloadVideo(
+      ids,
+    ).runAll(runnerCountForDownload)
+
+    logger.info(
+      `📥 Successfully downloaded ${successfullyDownloadedIds.length}/${ids.length} videos`,
+    )
+
+    if (successfullyDownloadedIds.length === 0) {
+      logger.warn(
+        '⚠️ No videos were successfully downloaded. Skipping processing.',
+      )
+      return
+    }
+
+    // ダウンロードしたプレイリスト動画を処理
+    await new ParallelProcessVideo(successfullyDownloadedIds).runAll(
+      runnerCountForProcessing,
+    )
+
+    // プレイリストにない音楽ファイルを削除
+    logger.info('🗑️ Deleting playlist removed tracks...')
+    deleteRemovedTracks(ids)
+
+    // ダウンロードした音楽ファイルを元にプレイリストファイルを作成
+    logger.info('📝 Creating playlist file...')
+    createPlaylistFile()
+
+    logger.info('🎉 Successfully finished!')
+  } catch (error) {
+    logger.error('Failed to run heavy pipeline', error as Error)
+  } finally {
+    isHeavyRunning = false
+    heavyTimeoutHandle = setTimeout(() => {
+      ;(async () => {
+        await runHeavyPipeline('scheduled')
+      })()
+    }, PIPELINE_INTERVAL_SECONDS * 1000)
+  }
+}
+
+/**
+ * プレイリストの新規動画IDを高頻度に検出するループを1回実行する
+ *
+ * 新規IDを検出した場合、重いパイプラインを即座にトリガーする。
+ * 完了後は、成否に関わらず次回の検出ループをスケジュールする。
+ */
+async function runDetectionLoop() {
+  const logger = Logger.configure('runDetectionLoop')
+
+  try {
+    const config = getConfig()
+    const ids = getPlaylistVideoIds(config.playlistId)
+    const newIds = ids.filter((id) => !lastKnownIds.includes(id))
+    lastKnownIds = ids
+
+    if (newIds.length > 0) {
+      logger.info(
+        `🆕 Detected ${newIds.length} new video(s): ${newIds.join(', ')}`,
+      )
+      await runHeavyPipeline('new-videos-detected')
+    }
+  } catch (error) {
+    logger.error('Failed to run detection loop', error as Error)
+  } finally {
+    setTimeout(() => {
+      ;(async () => {
+        await runDetectionLoop()
+      })()
+    }, DETECTION_INTERVAL_SECONDS * 1000)
+  }
+}
+
+async function main() {
+  const logger = Logger.configure('main')
+
+  logger.info('📝 Global configuration:')
+  logger.info(`  - Detection interval (sec): ${DETECTION_INTERVAL_SECONDS}`)
+  logger.info(`  - Pipeline interval (sec): ${PIPELINE_INTERVAL_SECONDS}`)
+
+  // 起動時に現在のID一覧を取得してベースラインとし、直後に重い処理を1回実行する
+  const config = getConfig()
+  lastKnownIds = getPlaylistVideoIds(config.playlistId)
+  await runHeavyPipeline('startup')
+
+  // 常駐ループを開始する(このプロセスは終了しない)
+  setTimeout(() => {
+    ;(async () => {
+      await runDetectionLoop()
+    })()
+  }, DETECTION_INTERVAL_SECONDS * 1000)
 }
 
 ;(async () => {


### PR DESCRIPTION
## 概要

現状、プレイリストへの新規動画追加の検出は 1 時間おきの重いダウンロード/処理パイプラインと同じループの中でしか行われておらず、新規動画が追加されてから検出・ダウンロードされるまで最大約 1 時間の遅延が発生していた。本 PR では、新規動画 ID の検出処理(`getPlaylistVideoIds()`)を重い処理から分離し、独立した高頻度ループ(デフォルト 5 分間隔)として実行するようにする。重い処理(ダウンロード・mp3gain・sox・echoprint 等)の実行頻度自体は変更しない(デフォルト 1 時間間隔)。

## 変更内容

- `downloader/src/main.ts` を常駐プロセスとして再構成
  - `runHeavyPipeline(reason)`: 既存のダウンロード/処理パイプラインを 1 回実行する関数として切り出し。多重実行防止用の `isHeavyRunning` フラグを追加。完了後は成否に関わらず次回の定期実行タイマー(`PIPELINE_INTERVAL_SECONDS`、デフォルト 3600 秒)を再設定する。
  - `runDetectionLoop()`: プレイリストの新規動画 ID を高頻度(`DETECTION_INTERVAL_SECONDS`、デフォルト 300 秒)に検出するループ。新規 ID を検出した場合は `runHeavyPipeline` を即座にトリガーする(トリガーした実行の完了は待たず、検出ループ自身は直ちに次回をスケジュールする)。
  - 起動時にベースラインとなる ID 一覧を取得したうえで、重い処理を 1 回実行してから両ループを開始する。
- `downloader/entrypoint.sh` を、1 時間ごとの固定間隔再起動ループから、プロセスがクラッシュした場合のみ再起動するループに変更。
- `README.md` に `DETECTION_INTERVAL_SECONDS` / `PIPELINE_INTERVAL_SECONDS` の 2 つの環境変数のドキュメントを追加。

## 動作確認

- `yarn compile`(downloader): エラーなし
- `yarn lint`(downloader): エラーなし(既存コードの無関係な warning 2 件を除く)

## スコープ外

SIGTERM / SIGINT によるグレースフルシャットダウン対応は本 PR のスコープ外とする(別途対応を検討)。

Closes #2886

Spec: https://github.com/tomacheese/fetch-youtube-bgm/issues/2886#issuecomment-5071853519
Plan: https://github.com/tomacheese/fetch-youtube-bgm/issues/2886#issuecomment-5072138940