### PR TITLE
fix(downloader): メタデータ一次フィルタによるCPU負荷軽減

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ services:
     init: true
 ```
 
+Every hourly run first performs a lightweight metadata pre-filter (via `yt-dlp --skip-download`) against each playlist video, and only videos whose `duration` / `filesize_approx` changed since the last run go through the full download → normalize → trim → fingerprint pipeline. This significantly reduces CPU load when the playlist content is mostly unchanged.
+
+The `downloader` service optionally accepts the following environment variable:
+
+- `RUNNER_COUNT_FOR_METADATA_CHECK`: Number of parallel workers used for the metadata pre-filter check at the start of each hourly run. Defaults to `5`.
+
 ### 3. Create a configuration file
 
 Create `data/config.json` and write the following JSON. Note that the strings enclosed in `<` and `>` should be replaced with the correct ones.

--- a/downloader/src/lib.ts
+++ b/downloader/src/lib.ts
@@ -447,6 +447,55 @@ export function getVideoMetadata(videoId: string): VideoMetadata | null {
   }
 }
 
+type VideoMetadataFile = Record<string, VideoMetadata>
+
+const VIDEO_METADATA_STORE_PATH = '/data/video-metadata.json'
+
+/**
+ * 動画メタデータの専用ストアを読み込む
+ *
+ * @returns 動画 ID をキーとしたメタデータの一覧。ファイルが存在しない場合は空オブジェクト
+ */
+export function getVideoMetadataStore(): VideoMetadataFile {
+  if (fs.existsSync(VIDEO_METADATA_STORE_PATH)) {
+    return JSON.parse(
+      fs.readFileSync(VIDEO_METADATA_STORE_PATH).toString(),
+    ) as VideoMetadataFile
+  }
+  return {}
+}
+
+/**
+ * 動画メタデータの専用ストアに単一動画のエントリを追加・更新する
+ *
+ * @param vid 動画 ID
+ * @param metadata 保存するメタデータ
+ */
+export function updateVideoMetadata(vid: string, metadata: VideoMetadata) {
+  const store = getVideoMetadataStore()
+  const next = {
+    ...store,
+    [vid]: metadata,
+  }
+  fs.writeFileSync(VIDEO_METADATA_STORE_PATH, JSON.stringify(next))
+}
+
+/**
+ * 動画メタデータの専用ストアから、現在のプレイリストに存在しない動画のエントリを削除する
+ *
+ * @param currentIds 現在のプレイリストに含まれる動画 ID の一覧
+ */
+export function pruneVideoMetadataStore(currentIds: string[]) {
+  const store = getVideoMetadataStore()
+  const next: VideoMetadataFile = {}
+  for (const vid in store) {
+    if (currentIds.includes(vid)) {
+      next[vid] = store[vid]
+    }
+  }
+  fs.writeFileSync(VIDEO_METADATA_STORE_PATH, JSON.stringify(next))
+}
+
 export function getEchoPrint(file: string) {
   const command = ['/usr/local/bin/echoprint-codegen', `"${file}"`, '10', '30']
   const result = execSync(command.join(' '))

--- a/downloader/src/lib.ts
+++ b/downloader/src/lib.ts
@@ -40,6 +40,11 @@ interface VideoInformation {
   artist: string
 }
 
+export interface VideoMetadata {
+  duration: number | null
+  filesizeApprox: number | null
+}
+
 export function getDefinedTracks(): Track[] {
   if (fs.existsSync('/data/tracks.json')) {
     const result = JSON.parse(
@@ -398,6 +403,47 @@ export function downloadVideo(videoId: string): boolean {
     return true
   } catch {
     return false
+  }
+}
+
+/**
+ * yt-dlp でダウンロードせずに動画のメタデータ(再生時間・概算ファイルサイズ)を取得する
+ *
+ * @param videoId 動画 ID
+ * @returns 取得できたメタデータ。コマンド自体が失敗した場合は null
+ */
+export function getVideoMetadata(videoId: string): VideoMetadata | null {
+  const logger = Logger.configure('getVideoMetadata')
+  const httpsProxy = process.env.HTTPS_PROXY ?? process.env.https_proxy
+  const command = [
+    'yt-dlp',
+    '--ignore-config',
+    httpsProxy ? '--proxy' : '',
+    httpsProxy ?? '',
+    '--skip-download',
+    '--add-header',
+    'Accept-Language:ja-JP',
+    '--print',
+    '"%(duration)s;%(filesize_approx)s"',
+    `https://youtu.be/${videoId}`,
+  ]
+  try {
+    const result = execSync(command.join(' '), {
+      cwd: DOWNLOAD_TEMP_DIR,
+    })
+    const [durationRaw, filesizeApproxRaw] = result
+      .toString()
+      .trim()
+      .split(';', 2)
+    const duration = Number.parseFloat(durationRaw)
+    const filesizeApprox = Number.parseFloat(filesizeApproxRaw)
+    return {
+      duration: Number.isNaN(duration) ? null : duration,
+      filesizeApprox: Number.isNaN(filesizeApprox) ? null : filesizeApprox,
+    }
+  } catch (error) {
+    logger.warn(`⚠️ Failed to get metadata for ${videoId}:`, error as Error)
+    return null
   }
 }
 

--- a/downloader/src/lib.ts
+++ b/downloader/src/lib.ts
@@ -342,10 +342,6 @@ export function trimAndAddSilence(file: string, duration: number) {
   return result
 }
 
-export function removeCacheDir() {
-  execSync('yt-dlp --rm-cache-dir')
-}
-
 export function recreateDirectories() {
   if (fs.existsSync(DOWNLOAD_TEMP_DIR)) {
     fs.rmSync(DOWNLOAD_TEMP_DIR, { recursive: true })

--- a/downloader/src/lib.ts
+++ b/downloader/src/lib.ts
@@ -1,13 +1,16 @@
 import axios, { AxiosProxyConfig } from 'axios'
-import { execSync } from 'node:child_process'
+import { exec, execSync } from 'node:child_process'
 import fs from 'node:fs'
 import NodeID3 from 'node-id3'
 import { Logger } from '@book000/node-utils'
 import sharp from 'sharp'
 import path from 'node:path'
+import { promisify } from 'node:util'
 import { Config } from './configuration'
 import { MusicBrainz } from './musicbrainz'
 import { DOWNLOAD_TEMP_DIR } from './constants'
+
+const execAsync = promisify(exec)
 
 interface Track {
   vid: string
@@ -408,7 +411,9 @@ export function downloadVideo(videoId: string): boolean {
  * @param videoId 動画 ID
  * @returns 取得できたメタデータ。コマンド自体が失敗した場合は null
  */
-export function getVideoMetadata(videoId: string): VideoMetadata | null {
+export async function getVideoMetadata(
+  videoId: string,
+): Promise<VideoMetadata | null> {
   const logger = Logger.configure('getVideoMetadata')
   const httpsProxy = process.env.HTTPS_PROXY ?? process.env.https_proxy
   const command = [
@@ -424,13 +429,12 @@ export function getVideoMetadata(videoId: string): VideoMetadata | null {
     `https://youtu.be/${videoId}`,
   ]
   try {
-    const result = execSync(command.join(' '), {
+    // execSync だと呼び出し中 Node プロセス全体がブロックされ、複数動画分の
+    // yt-dlp 呼び出しを並列実行できないため、ここだけ非同期の exec を使う
+    const { stdout } = await execAsync(command.join(' '), {
       cwd: DOWNLOAD_TEMP_DIR,
     })
-    const [durationRaw, filesizeApproxRaw] = result
-      .toString()
-      .trim()
-      .split(';', 2)
+    const [durationRaw, filesizeApproxRaw] = stdout.trim().split(';', 2)
     const duration = Number.parseFloat(durationRaw)
     const filesizeApprox = Number.parseFloat(filesizeApproxRaw)
     return {

--- a/downloader/src/lib.ts
+++ b/downloader/src/lib.ts
@@ -442,7 +442,16 @@ export async function getVideoMetadata(
       filesizeApprox: Number.isNaN(filesizeApprox) ? null : filesizeApprox,
     }
   } catch (error) {
-    logger.warn(`⚠️ Failed to get metadata for ${videoId}:`, error as Error)
+    // error.message には実行したシェルコマンド全体(プロキシの認証情報が
+    // 埋め込まれている場合はそれも含む)が含まれるため、ログには出力しない。
+    // yt-dlp 自身のエラー出力である stderr のみを診断情報として残す
+    const stderr =
+      typeof error === 'object' && error !== null && 'stderr' in error
+        ? String(error.stderr)
+        : undefined
+    logger.warn(
+      `⚠️ Failed to get metadata for ${videoId}${stderr ? `: ${stderr}` : ''}`,
+    )
     return null
   }
 }
@@ -454,15 +463,39 @@ const VIDEO_METADATA_STORE_PATH = '/data/video-metadata.json'
 /**
  * 動画メタデータの専用ストアを読み込む
  *
- * @returns 動画 ID をキーとしたメタデータの一覧。ファイルが存在しない場合は空オブジェクト
+ * @returns 動画 ID をキーとしたメタデータの一覧。ファイルが存在しない、または
+ * 内容が壊れている場合は空オブジェクト(fail-open)
  */
 export function getVideoMetadataStore(): VideoMetadataFile {
-  if (fs.existsSync(VIDEO_METADATA_STORE_PATH)) {
+  if (!fs.existsSync(VIDEO_METADATA_STORE_PATH)) {
+    return {}
+  }
+  try {
     return JSON.parse(
       fs.readFileSync(VIDEO_METADATA_STORE_PATH).toString(),
     ) as VideoMetadataFile
+  } catch (error) {
+    const logger = Logger.configure('getVideoMetadataStore')
+    logger.warn(
+      `⚠️ Failed to parse video metadata store, treating as empty:`,
+      error as Error,
+    )
+    return {}
   }
-  return {}
+}
+
+/**
+ * 動画メタデータの専用ストアファイルへ書き込む
+ *
+ * 書き込み途中でプロセスが停止しても壊れたファイルが残らないよう、
+ * 一時ファイルへ書き込んでからリネームすることでアトミックに反映する
+ *
+ * @param store 書き込む内容
+ */
+function writeVideoMetadataStore(store: VideoMetadataFile) {
+  const tempPath = `${VIDEO_METADATA_STORE_PATH}.tmp`
+  fs.writeFileSync(tempPath, JSON.stringify(store))
+  fs.renameSync(tempPath, VIDEO_METADATA_STORE_PATH)
 }
 
 /**
@@ -477,7 +510,7 @@ export function updateVideoMetadata(vid: string, metadata: VideoMetadata) {
     ...store,
     [vid]: metadata,
   }
-  fs.writeFileSync(VIDEO_METADATA_STORE_PATH, JSON.stringify(next))
+  writeVideoMetadataStore(next)
 }
 
 /**
@@ -493,7 +526,7 @@ export function pruneVideoMetadataStore(currentIds: string[]) {
       next[vid] = store[vid]
     }
   }
-  fs.writeFileSync(VIDEO_METADATA_STORE_PATH, JSON.stringify(next))
+  writeVideoMetadataStore(next)
 }
 
 export function getEchoPrint(file: string) {

--- a/downloader/src/main.ts
+++ b/downloader/src/main.ts
@@ -18,12 +18,12 @@ import {
   getVideoMetadata,
   getVideoMetadataStore,
   normalizeVolume,
-  removeCacheDir,
   updateArtwork,
   trimAndAddSilence,
   isSetArtwork,
   getArtworkData,
   updateVideoMetadata,
+  pruneVideoMetadataStore,
   VideoMetadata,
 } from './lib'
 import { Logger } from '@book000/node-utils'
@@ -121,7 +121,7 @@ class ParallelDownloadVideo {
 class ParallelFetchVideoMetadata {
   private readonly ids: string[]
   private readonly videoCount: number
-  private readonly store: Record<string, VideoMetadata>
+  private readonly store: Record<string, VideoMetadata | undefined>
   private readonly metadataByVideoId = new Map<string, VideoMetadata>()
   private readonly idsToProcess: string[] = []
 
@@ -189,8 +189,7 @@ class ParallelFetchVideoMetadata {
 
     const previous = this.store[id]
     const changed =
-      !previous ||
-      previous.duration !== metadata.duration ||
+      previous?.duration !== metadata.duration ||
       previous.filesizeApprox !== metadata.filesizeApprox
 
     if (!changed) {
@@ -485,6 +484,10 @@ async function main() {
   const runnerCountForProcessing = process.env.RUNNER_COUNT_FOR_PROCESSING
     ? Number.parseInt(process.env.RUNNER_COUNT_FOR_PROCESSING, 10)
     : 3
+  const runnerCountForMetadataCheck = process.env
+    .RUNNER_COUNT_FOR_METADATA_CHECK
+    ? Number.parseInt(process.env.RUNNER_COUNT_FOR_METADATA_CHECK, 10)
+    : 5
 
   logger.info('📝 Configuration:')
   logger.info(`  - Playlist ID: ${playlistId}`)
@@ -494,42 +497,61 @@ async function main() {
   )
   logger.info(`  - Runner count for download: ${runnerCountForDownload}`)
   logger.info(`  - Runner count for processing: ${runnerCountForProcessing}`)
+  logger.info(
+    `  - Runner count for metadata check: ${runnerCountForMetadataCheck}`,
+  )
 
   logger.info('📁 Recreating directories...')
   recreateDirectories()
 
-  logger.info('🗑️ Deleting yt-dlp cache...')
-  removeCacheDir()
-
   logger.info(`📚 Getting playlist videos for ${playlistId}`)
   const ids = getPlaylistVideoIds(playlistId)
 
-  logger.info(`🎥 Found ${ids.length} videos. Downloading...`)
+  logger.info(`🎥 Found ${ids.length} videos. Checking metadata...`)
 
-  // プレイリスト動画をダウンロード
-  const successfullyDownloadedIds = await new ParallelDownloadVideo(ids).runAll(
-    runnerCountForDownload,
-  )
+  // メタデータ一次フィルタ: 変更のない動画をダウンロード対象から除外
+  const { idsToProcess, metadataByVideoId } =
+    await new ParallelFetchVideoMetadata(ids).runAll(
+      runnerCountForMetadataCheck,
+    )
 
   logger.info(
-    `📥 Successfully downloaded ${successfullyDownloadedIds.length}/${ids.length} videos`,
+    `📊 ${idsToProcess.length}/${ids.length} videos need processing (skipped ${
+      ids.length - idsToProcess.length
+    } unchanged videos)`,
   )
 
-  if (successfullyDownloadedIds.length === 0) {
-    logger.warn(
-      '⚠️ No videos were successfully downloaded. Skipping processing.',
+  if (idsToProcess.length > 0) {
+    // プレイリスト動画をダウンロード
+    const successfullyDownloadedIds = await new ParallelDownloadVideo(
+      idsToProcess,
+    ).runAll(runnerCountForDownload)
+
+    logger.info(
+      `📥 Successfully downloaded ${successfullyDownloadedIds.length}/${idsToProcess.length} videos`,
     )
-    return
-  }
 
-  // ダウンロードしたプレイリスト動画を処理
-  await new ParallelProcessVideo(successfullyDownloadedIds).runAll(
-    runnerCountForProcessing,
-  )
+    if (successfullyDownloadedIds.length === 0) {
+      // 元の実装(全動画のダウンロードに失敗した場合、以降の処理を行わず終了する)を踏襲する
+      logger.warn(
+        '⚠️ No videos were successfully downloaded. Skipping processing.',
+      )
+      return
+    }
+
+    // ダウンロードしたプレイリスト動画を処理
+    await new ParallelProcessVideo(
+      successfullyDownloadedIds,
+      metadataByVideoId,
+    ).runAll(runnerCountForProcessing)
+  }
 
   // プレイリストにない音楽ファイルを削除
   logger.info('🗑️ Deleting playlist removed tracks...')
   deleteRemovedTracks(ids)
+
+  // 専用ストアからプレイリストに存在しない動画のエントリを削除
+  pruneVideoMetadataStore(ids)
 
   // ダウンロードした音楽ファイルを元にプレイリストファイルを作成
   logger.info('📝 Creating playlist file...')

--- a/downloader/src/main.ts
+++ b/downloader/src/main.ts
@@ -135,7 +135,7 @@ class ParallelFetchVideoMetadata {
    * すべての動画についてメタデータ一次フィルタを実行する
    *
    * @param runnerCount 並列実行数 (デフォルト: 5)
-   * @returns 処理が必要な動画IDと、そのうち新規に取得できたメタデータ
+   * @returns 処理が必要な動画 ID と、そのうち新規に取得できたメタデータ
    */
   public async runAll(runnerCount = 5): Promise<{
     idsToProcess: string[]
@@ -188,17 +188,35 @@ class ParallelFetchVideoMetadata {
     }
 
     const previous = this.store[id]
+    // 1つ目の条件が false ということは previous が存在することを意味するため、
+    // 2つ目の条件では previous を non-null として扱ってよい(TS の型絞り込みによる)
     const changed =
       previous?.duration !== metadata.duration ||
       previous.filesizeApprox !== metadata.filesizeApprox
 
-    if (!changed) {
+    if (!changed && (await this.hasExistingTrackFile(id))) {
       logger.info(`⏭️ Skipping ${id} because metadata is unchanged`)
       return
     }
 
     this.metadataByVideoId.set(id, metadata)
     this.idsToProcess.push(id)
+  }
+
+  /**
+   * 前回処理時に生成されたはずの mp3 ファイルが、現在もディスク上に存在するかを確認する
+   *
+   * メタデータに変更がなくても、出力先ファイルが外部要因(手動削除・破損等)で
+   * 失われている場合は再処理が必要なため、スキップ判定の前提としてこのチェックを行う
+   *
+   * @param id 動画 ID
+   * @returns ファイルが存在すれば true
+   */
+  private async hasExistingTrackFile(id: string): Promise<boolean> {
+    const config = getConfig()
+    const track = await getTrack(id)
+    const filename = getFilename(config, track)
+    return fs.existsSync(`/data/tracks/${filename}`)
   }
 }
 
@@ -419,7 +437,7 @@ class ParallelProcessVideo {
   /**
    * 一次フィルタで取得済みのメタデータがあれば、専用ストアへ反映する
    *
-   * 一次フィルタが失敗していた動画IDについては、更新に使えるメタデータが
+   * 一次フィルタが失敗していた動画 ID については、更新に使えるメタデータが
    * 存在しないためストアを更新しない(前回値のまま据え置き、次回実行時に
    * 再度「変更あり」として扱われる)
    *

--- a/downloader/src/main.ts
+++ b/downloader/src/main.ts
@@ -15,12 +15,16 @@ import {
   getPlaylistVideoIds,
   getTrack,
   getVideoInformation,
+  getVideoMetadata,
+  getVideoMetadataStore,
   normalizeVolume,
   removeCacheDir,
   updateArtwork,
   trimAndAddSilence,
   isSetArtwork,
   getArtworkData,
+  updateVideoMetadata,
+  VideoMetadata,
 } from './lib'
 import { Logger } from '@book000/node-utils'
 import { DOWNLOAD_TEMP_DIR } from './constants'
@@ -111,6 +115,91 @@ class ParallelDownloadVideo {
       return false
     }
     return true
+  }
+}
+
+class ParallelFetchVideoMetadata {
+  private readonly ids: string[]
+  private readonly videoCount: number
+  private readonly store: Record<string, VideoMetadata>
+  private readonly metadataByVideoId = new Map<string, VideoMetadata>()
+  private readonly idsToProcess: string[] = []
+
+  constructor(ids: string[]) {
+    this.ids = [...ids]
+    this.videoCount = ids.length
+    this.store = getVideoMetadataStore()
+  }
+
+  /**
+   * すべての動画についてメタデータ一次フィルタを実行する
+   *
+   * @param runnerCount 並列実行数 (デフォルト: 5)
+   * @returns 処理が必要な動画IDと、そのうち新規に取得できたメタデータ
+   */
+  public async runAll(runnerCount = 5): Promise<{
+    idsToProcess: string[]
+    metadataByVideoId: Map<string, VideoMetadata>
+  }> {
+    const runners = []
+    for (let i = 0; i < runnerCount; i++) {
+      runners.push(this.runner(i))
+    }
+
+    await Promise.all(runners)
+    return {
+      idsToProcess: this.idsToProcess,
+      metadataByVideoId: this.metadataByVideoId,
+    }
+  }
+
+  private async runner(runnerId: number) {
+    const logger = Logger.configure(
+      `ParallelFetchVideoMetadata.runner#${runnerId.toString()}`,
+    )
+    logger.info(`Starting metadata check runner #${runnerId}`)
+    while (this.ids.length > 0) {
+      const id = this.ids.pop()
+      if (!id) {
+        break
+      }
+      const videoIndex = this.videoCount - this.ids.length
+      logger.info(
+        `📊 Checking metadata for ${id} (${videoIndex} / ${this.videoCount})`,
+      )
+      await this.checkVideo(id)
+    }
+  }
+
+  /**
+   * 動画のメタデータを取得し、前回値と比較して処理が必要かどうかを判定する
+   *
+   * @param id 動画 ID
+   */
+  private async checkVideo(id: string) {
+    const logger = Logger.configure(
+      `ParallelFetchVideoMetadata.checkVideo#${id}`,
+    )
+    const metadata = await getVideoMetadata(id)
+    if (!metadata) {
+      logger.warn(`⚠️ Failed to get metadata for ${id}, treating as changed`)
+      this.idsToProcess.push(id)
+      return
+    }
+
+    const previous = this.store[id]
+    const changed =
+      !previous ||
+      previous.duration !== metadata.duration ||
+      previous.filesizeApprox !== metadata.filesizeApprox
+
+    if (!changed) {
+      logger.info(`⏭️ Skipping ${id} because metadata is unchanged`)
+      return
+    }
+
+    this.metadataByVideoId.set(id, metadata)
+    this.idsToProcess.push(id)
   }
 }
 

--- a/downloader/src/main.ts
+++ b/downloader/src/main.ts
@@ -206,10 +206,12 @@ class ParallelFetchVideoMetadata {
 class ParallelProcessVideo {
   private readonly ids: string[]
   private readonly videoCount: number
+  private readonly metadataByVideoId: Map<string, VideoMetadata>
 
-  constructor(ids: string[]) {
+  constructor(ids: string[], metadataByVideoId: Map<string, VideoMetadata>) {
     this.ids = [...ids]
     this.videoCount = ids.length
+    this.metadataByVideoId = metadataByVideoId
   }
 
   public async runAll(runnerCount = 3) {
@@ -360,6 +362,7 @@ class ParallelProcessVideo {
         getEchoPrint(downloadedFilePath)
     ) {
       logger.info(`⏭️ Skipping because the file is the same: ${id}`)
+      this.updateMetadataStoreIfFetched(id)
       return
     }
 
@@ -380,6 +383,7 @@ class ParallelProcessVideo {
     }
 
     logger.info(`✅ Successfully processed ${id}`)
+    this.updateMetadataStoreIfFetched(id)
 
     const baseUrl = process.env.BASE_URL ?? undefined
     const editUrl = baseUrl ? `${baseUrl}?vid=${id}` : undefined
@@ -411,6 +415,22 @@ class ParallelProcessVideo {
         },
       ],
     })
+  }
+
+  /**
+   * 一次フィルタで取得済みのメタデータがあれば、専用ストアへ反映する
+   *
+   * 一次フィルタが失敗していた動画IDについては、更新に使えるメタデータが
+   * 存在しないためストアを更新しない(前回値のまま据え置き、次回実行時に
+   * 再度「変更あり」として扱われる)
+   *
+   * @param id 動画 ID
+   */
+  private updateMetadataStoreIfFetched(id: string) {
+    const metadata = this.metadataByVideoId.get(id)
+    if (metadata) {
+      updateVideoMetadata(id, metadata)
+    }
   }
 }
 


### PR DESCRIPTION
## 概要

`downloader` が毎時、プレイリスト内の全動画に対して「ダウンロード → mp3gain(音量正規化) → sox(トリム/無音付与) → echoprint 比較」というフルパイプラインを無条件に実行しており、変更のない動画に対しても毎回同じ重い処理を繰り返していた問題を解消する。

## 変更内容

- `yt-dlp --skip-download --print` による軽量なメタデータ(`duration` / `filesize_approx`)一次フィルタを追加し、専用ストア(`/data/video-metadata.json`)へ保存した前回値と比較する。
  - 新規動画・前回値と不一致・取得失敗の場合は「変更あり」として処理対象に含める(fail-open)。
  - 前回値と完全一致し、かつ前回処理済みの mp3 ファイルが実在する場合のみ、ダウンロード以降の重い処理をスキップする。
  - 出力ファイルが外部要因で消失していた場合は、メタデータが未変更でも再処理する(自己修復性)。
- 「変更あり」と判定された動画のみ、既存のダウンロード・mp3gain・sox・echoprint 比較パイプラインを実行する。最終判定は引き続き echoprint 比較で行う。
- `removeCacheDir()`(`yt-dlp --rm-cache-dir`)の毎回実行を廃止し、yt-dlp 自身の再エンコード回避キャッシュを活かす。
- 一次フィルタの並列実行数を環境変数 `RUNNER_COUNT_FOR_METADATA_CHECK`(デフォルト `5`)で設定可能にする。
- `getVideoMetadata` の失敗ログにシェルコマンド全体(プロキシ認証情報を含みうる)を出力しないよう、yt-dlp の `stderr` のみを記録する。
- メタデータストアの読み込みはファイル破損時に fail-open(空オブジェクト)、書き込みは一時ファイル + rename によるアトミック書き込みとする。
- `README.md` に処理フローと `RUNNER_COUNT_FOR_METADATA_CHECK` の説明を追記する。

## 動作確認

- `yarn compile`: エラーなし
- `yarn lint`: エラーなし(master 由来の既存警告 2 件のみ残存、本 PR の変更とは無関係)
- `/deep-review`(ローカル diff モード)で検出されたスコア 50 以上の指摘 7 件をすべて修正済み

Closes #2885

Spec: [Issue comment URL](https://github.com/tomacheese/fetch-youtube-bgm/issues/2885#issuecomment-5071900100)
Plan: [Issue comment URL](https://github.com/tomacheese/fetch-youtube-bgm/issues/2885#issuecomment-5072084955)