### PR TITLE
fix(viewer): server/api ルートが機能しない問題を修正

### DIFF
--- a/viewer/nuxt.config.ts
+++ b/viewer/nuxt.config.ts
@@ -48,6 +48,8 @@ export default defineNuxtConfig({
 
   srcDir: 'src/',
 
+  serverDir: 'src/server/',
+
   ssr: isSsr,
 
   typescript: {


### PR DESCRIPTION
## 概要

`viewer` の `/api/tracks` をはじめとする `server/api` 配下の全ルートが、実運用環境で常に SPA フォールバック HTML を返してしまい、実データ(JSON)が取得できない問題を修正する。

## 原因

`viewer/nuxt.config.ts` は `srcDir: 'src/'` を設定しているが、Nitro のサーバールート探索ディレクトリ(`serverDir`)は `srcDir` の影響を受けず、未指定時は既定の `<rootDir>/server/` を参照する。実際のルートは `viewer/src/server/api/` に配置されているため、ビルド時に一切拾われず、`/api/tracks` などへのリクエストが全て SPA フォールバックにフォールスルーしていた。

## 修正内容

`viewer/nuxt.config.ts` に `serverDir: 'src/server/'` を追加。

## 動作確認

- `yarn lint`: 0 エラー
- `yarn build`: `.output/server/chunks/routes/api/tracks/_vid_.get.mjs`、`api/tracks-raw.get.mjs`、`api/webhook.post.mjs` などのサーバールートが生成されることを確認(修正前は生成されなかった)

Closes #2890