### PR TITLE
fix(downloader): 起動時に一時ディレクトリを作成

### DIFF
--- a/downloader/src/main.ts
+++ b/downloader/src/main.ts
@@ -665,6 +665,9 @@ async function main() {
   logger.info(`  - Detection interval (sec): ${DETECTION_INTERVAL_SECONDS}`)
   logger.info(`  - Pipeline interval (sec): ${PIPELINE_INTERVAL_SECONDS}`)
 
+  logger.info('📁 Recreating directories...')
+  recreateDirectories()
+
   // 起動時に現在の ID 一覧を取得してベースラインとし、直後に重い処理を 1 回実行する
   const config = getConfig()
   lastKnownIds = getPlaylistVideoIds(config.playlistId)


### PR DESCRIPTION
Closes #2915

## 概要

起動時のベースライン取得前に一時ディレクトリを再作成し、`yt-dlp` の `cwd` が存在しないことによるクラッシュループを防止します。

既存の重いパイプライン開始時の再作成処理は維持しています。

## 検証

- `yarn compile`
- `yarn lint`

## 判断記録

- 起動前に `recreateDirectories()` を実行する案を採用しました。初回の `getPlaylistVideoIds()` より前に対象ディレクトリの存在を保証でき、既存のパイプライン処理の責務を変えないためです。
- `getPlaylistVideoIds()` ごとにディレクトリを作成する防御策は採用しませんでした。ディレクトリのライフサイクルを個別のコマンド実行に分散させず、既存の初期化処理に集約するためです。
- 前提は、`recreateDirectories()` が `/tmp/download-movies` を作成する既存の唯一の初期化処理であることです。自動テストは存在しないため、型チェックと静的検証で確認しました。
- 他エージェントによるレビューは未実施です。