### PR TITLE
chore: .worktreeinclude を追加

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,4 @@
+data/config.json
+data/tracks.json
+data/webhook-tracks.json
+data/tracks/


### PR DESCRIPTION
## 概要

Git worktree 作成時に自動でコピーされるべきローカル専用データファイルを指定する `.worktreeinclude` を追加した。

## 追加したパターン

```
data/config.json
data/tracks.json
data/webhook-tracks.json
data/tracks/
```

## 根拠（調査結果の要約）

- `downloader/src/configuration.ts` は `CONFIG_PATH`（既定値 `./data/config.json`）から設定を読み込む。
- ルートの `.gitignore` は `data/*`（`!data/.gitkeep` を除く）と `config.json` を除外しており、`data/config.json` はリポジトリに含まれない。
- README.md のインストール手順では `data/config.json` を手動作成する手順のみが案内されており、`config.example.json` 等のテンプレートファイルは存在しない。
- `viewer/src/server/utils/track-manager.ts` / `webhook-track-manager.ts` はそれぞれ `TRACKS_FILE`（既定 `data/tracks.json`）、`TRACKS_DIR`（既定 `data/tracks/`）からローカルデータを読み込む。

これらはいずれも Git 管理外のローカル専用ファイルであり、新しい worktree 作成時に手動で再作成・再設定する手間を省くため `.worktreeinclude` に追加した。

## 関連

- https://github.com/book000/book000/issues/132