### PR TITLE
fix: artwork の切り出し範囲を動的に算出

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ data/*
 config.json
 node_modules
 dist
+.worktrees/

--- a/downloader/src/lib.ts
+++ b/downloader/src/lib.ts
@@ -305,17 +305,38 @@ export async function getArtworkData(vid: string) {
   return null
 }
 
+/**
+ * 動画サムネイルの中央を最大の正方形として切り出す
+ *
+ * @param vid 動画 ID
+ * @returns 加工済み artwork。取得または加工できない場合は null
+ */
 export async function getClippedArtwork(vid: string) {
   const artworkData = await getArtworkData(vid)
   if (!artworkData) return null
-  return await sharp(artworkData)
-    .extract({
-      left: 280,
-      top: 0,
-      width: 720,
-      height: 720,
-    })
-    .toBuffer()
+
+  const logger = Logger.configure('getClippedArtwork')
+  try {
+    const image = sharp(artworkData)
+    const { width, height } = await image.metadata()
+    if (!width || !height) {
+      logger.warn(`🚫 Failed to get artwork dimensions for ${vid}`)
+      return null
+    }
+
+    const side = Math.min(width, height)
+    return await image
+      .extract({
+        left: Math.floor((width - side) / 2),
+        top: Math.floor((height - side) / 2),
+        width: side,
+        height: side,
+      })
+      .toBuffer()
+  } catch (error) {
+    logger.warn(`⚠️ Failed to clip artwork for ${vid}:`, error as Error)
+    return null
+  }
 }
 
 export function normalizeVolume(file: string) {


### PR DESCRIPTION
Closes #2952

## 概要

低解像度の YouTube サムネイルへフォールバックした場合も、入力画像の中央から安全に最大の正方形を切り出します。

## 変更内容

- Sharp metadata から画像サイズを取得し、中央の最大正方形を crop
- artwork の metadata・crop・buffer 生成の失敗を warning と `null` に閉じ、heavy pipeline への伝播を防止
- worktree 用の `.worktrees/` を Git 管理から除外

## 検証

- `yarn lint`
- `yarn compile:test`
- 1280×720、640×480、破損画像の focused runtime check
- `5HWyR7sy5OA` と `ex0g2EbOCXo` の `sddefault.jpg` フォールバック確認（各 480×480）

## 現在の状態

CI はすべて成功しています。ローカル lightweight review は指摘なしで完了しており、未解決のレビューはありません。Copilot review を依頼しましたが、helper は割り当てを確認できませんでした。