### PR TITLE
chore: YouTubeサムネイルの想定内fallbackをGlitchTip warningに送信しない

### DIFF
--- a/downloader/src/lib.ts
+++ b/downloader/src/lib.ts
@@ -289,7 +289,8 @@ export async function getArtworkData(vid: string) {
         validateStatus: () => true,
       })
       if (secondResponse.status !== 200) {
-        logger.warn(
+        // 個別解像度の 404 は fallback 設計上の想定内事象のため、GlitchTip 等の監視ノイズにしない
+        logger.debug(
           `⏭️ Failed to get artwork for ${vid} at ${resolution} (${firstResponse.status} / ${secondResponse.status}), trying next resolution`,
         )
         continue


### PR DESCRIPTION
## 概要

YouTube サムネイル取得の想定内 fallback (`maxresdefault.jpg -> 404 -> sddefault.jpg -> 200` 等) が、途中経過の 404 ごとに `logger.warn` を発報しており、`@book000/node-utils` の `SentryTransport` が `warn`/`error` レベルのログを GlitchTip へ転送する仕様上、正常動作が監視ノイズになっていた (`FETCH-YOUTUBE-BGM-1` / 129、`FETCH-YOUTUBE-BGM-2` / 130)。

## 変更内容

- `downloader/src/lib.ts` の `getArtworkData` にて、個別解像度の 404 ログを `logger.warn` から `logger.debug` に変更。
- 全解像度の取得が失敗した場合の `logger.warn` (`🚫 Failed to get artwork for ${vid} at all resolutions`) は変更なし。

## Acceptance Criteria 対応状況

- [x] `maxresdefault` 等の候補画像 404 は debug 相当になる。
- [x] fallback 成功時は GlitchTip warning/error を送信しない。
- [x] 全候補画像の取得失敗時のみ warning/error になる。
- [ ] fallback 成功/全失敗の両ケースをテストで区別できる。

最後の項目については、downloader プロジェクトに現状テストランナー(jest/vitest 等)が存在せず、新規導入は別途の設計判断となるため、ユーザーの承認を得た上でスコープ外とした。

Closes #2967