### PR TITLE
fix: yt-dlp失敗時にstderrとexit statusを保持して原因を追跡可能にする

### DIFF
--- a/downloader/src/lib.ts
+++ b/downloader/src/lib.ts
@@ -421,6 +421,12 @@ export interface DownloadResult {
   stderr: string | null
 }
 
+/**
+ * yt-dlp で動画をダウンロードする
+ *
+ * @param videoId 動画 ID
+ * @returns ダウンロード結果。失敗時は yt-dlp の exit code と sanitized stderr を含む
+ */
 export function downloadVideo(videoId: string): DownloadResult {
   const httpsProxy = process.env.HTTPS_PROXY ?? process.env.https_proxy
   const command = [
@@ -446,8 +452,7 @@ export function downloadVideo(videoId: string): DownloadResult {
     })
     return { success: true, exitCode: 0, stderr: null }
   } catch (error) {
-    // error.message にはプロキシ認証情報を含みうるコマンド全体が含まれるため、
-    // これまで通り message は使わず、stderr のみを診断情報として扱う
+    // error.message はプロキシ認証情報を含みうるコマンド全体を含むため、stderr のみを診断情報として扱う
     const exitCode =
       typeof error === 'object' && error !== null && 'status' in error
         ? (error.status as number | null)
@@ -506,7 +511,7 @@ export async function getVideoMetadata(
     // yt-dlp 自身のエラー出力である stderr のみを診断情報として残す
     const stderr =
       typeof error === 'object' && error !== null && 'stderr' in error
-        ? String(error.stderr)
+        ? sanitizeSecrets(String(error.stderr))
         : undefined
     logger.warn(
       `⚠️ Failed to get metadata for ${videoId}${stderr ? `: ${stderr}` : ''}`,

--- a/downloader/src/lib.ts
+++ b/downloader/src/lib.ts
@@ -565,3 +565,17 @@ export function getHumanReadableSize(bytes: number) {
   const i = Math.floor(Math.log(bytes) / Math.log(1024))
   return `${(bytes / Math.pow(1024, i)).toFixed(2)} ${units[i]}`
 }
+
+/**
+ * stderr 等の診断文字列から秘密情報(URL 内の認証情報、Cookie / Authorization
+ * ヘッダーの値)を scrub する
+ *
+ * @param text scrub 対象の文字列
+ * @returns 秘密情報を scrub した文字列
+ */
+export function sanitizeSecrets(text: string): string {
+  return text
+    .replaceAll(/(\w+:\/\/)[^/\s:@]+:[^/\s@]+@/g, '$1***:***@')
+    .replaceAll(/(Cookie:\s*).+/gi, '$1***')
+    .replaceAll(/(Authorization:\s*).+/gi, '$1***')
+}

--- a/downloader/src/lib.ts
+++ b/downloader/src/lib.ts
@@ -398,7 +398,30 @@ export function getPlaylistVideoIds(playlistId: string) {
   return result.toString().split('\n').filter(Boolean)
 }
 
-export function downloadVideo(videoId: string): boolean {
+/**
+ * stderr 等の診断文字列から秘密情報(URL 内の認証情報、Cookie / Authorization
+ * ヘッダーの値)を scrub する
+ *
+ * @param text scrub 対象の文字列
+ * @returns 秘密情報を scrub した文字列
+ */
+export function sanitizeSecrets(text: string): string {
+  return text
+    .replaceAll(/(\w+:\/\/)[^/\s:@]+:[^/\s@]+@/g, '$1***:***@')
+    .replaceAll(/(Cookie:\s*).+/gi, '$1***')
+    .replaceAll(/(Authorization:\s*).+/gi, '$1***')
+}
+
+/**
+ * yt-dlp によるダウンロード結果
+ */
+export interface DownloadResult {
+  success: boolean
+  exitCode: number | null
+  stderr: string | null
+}
+
+export function downloadVideo(videoId: string): DownloadResult {
   const httpsProxy = process.env.HTTPS_PROXY ?? process.env.https_proxy
   const command = [
     'yt-dlp',
@@ -421,9 +444,23 @@ export function downloadVideo(videoId: string): boolean {
     execSync(command.join(' '), {
       cwd: DOWNLOAD_TEMP_DIR,
     })
-    return true
-  } catch {
-    return false
+    return { success: true, exitCode: 0, stderr: null }
+  } catch (error) {
+    // error.message にはプロキシ認証情報を含みうるコマンド全体が含まれるため、
+    // これまで通り message は使わず、stderr のみを診断情報として扱う
+    const exitCode =
+      typeof error === 'object' && error !== null && 'status' in error
+        ? (error.status as number | null)
+        : null
+    const rawStderr =
+      typeof error === 'object' && error !== null && 'stderr' in error
+        ? String(error.stderr)
+        : null
+    return {
+      success: false,
+      exitCode,
+      stderr: rawStderr ? sanitizeSecrets(rawStderr) : null,
+    }
   }
 }
 
@@ -564,18 +601,4 @@ export function getHumanReadableSize(bytes: number) {
   const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
   const i = Math.floor(Math.log(bytes) / Math.log(1024))
   return `${(bytes / Math.pow(1024, i)).toFixed(2)} ${units[i]}`
-}
-
-/**
- * stderr 等の診断文字列から秘密情報(URL 内の認証情報、Cookie / Authorization
- * ヘッダーの値)を scrub する
- *
- * @param text scrub 対象の文字列
- * @returns 秘密情報を scrub した文字列
- */
-export function sanitizeSecrets(text: string): string {
-  return text
-    .replaceAll(/(\w+:\/\/)[^/\s:@]+:[^/\s@]+@/g, '$1***:***@')
-    .replaceAll(/(Cookie:\s*).+/gi, '$1***')
-    .replaceAll(/(Authorization:\s*).+/gi, '$1***')
 }

--- a/downloader/src/main.ts
+++ b/downloader/src/main.ts
@@ -7,6 +7,7 @@ import {
   addTrack,
   recreateDirectories,
   downloadVideo,
+  DownloadResult,
   getClippedArtwork,
   getEchoPrint,
   getFilename,
@@ -88,10 +89,14 @@ class ParallelDownloadVideo {
     )
     const filePath = path.join(DOWNLOAD_TEMP_DIR, `${id}.mp3`)
 
+    let lastResult: DownloadResult | null = null
+    let lastAttempt = 0
+
     // MAX_DOWNLOAD_RETRIES回までリトライする
     for (let i = 0; i < MAX_DOWNLOAD_RETRIES; i++) {
-      const result = downloadVideo(id)
-      if (result) {
+      lastAttempt = i + 1
+      lastResult = downloadVideo(id)
+      if (lastResult.success) {
         try {
           const stats = await fsPromises.stat(filePath)
           const humanFileSize = getHumanReadableSize(stats.size)
@@ -109,8 +114,17 @@ class ParallelDownloadVideo {
     try {
       await fsPromises.access(filePath)
     } catch {
-      logger.warn(
+      const detail = [
+        `videoId=${id}`,
+        `attempt=${lastAttempt.toString()}/${MAX_DOWNLOAD_RETRIES.toString()}`,
+        `exitCode=${lastResult?.exitCode ?? 'unknown'}`,
+        lastResult?.stderr ? `stderr=${lastResult.stderr}` : undefined,
+      ]
+        .filter(Boolean)
+        .join(' ')
+      logger.error(
         `⚠️ Skipping ${id} due to download failure after ${MAX_DOWNLOAD_RETRIES} retries`,
+        new Error(detail),
       )
       return false
     }

--- a/downloader/src/main.ts
+++ b/downloader/src/main.ts
@@ -122,7 +122,7 @@ class ParallelDownloadVideo {
       ]
         .filter(Boolean)
         .join(' ')
-      logger.error(
+      logger.warn(
         `⚠️ Skipping ${id} due to download failure after ${MAX_DOWNLOAD_RETRIES} retries`,
         new Error(detail),
       )


### PR DESCRIPTION
## 概要

yt-dlp によるダウンロードが失敗した際、失敗理由(exit code / stderr)が失われて `Skipping <videoId> due to download failure after 3 retries` としか記録されない問題を修正する。

## 変更内容

- `downloader/src/lib.ts`
  - `downloadVideo()` の戻り値を `boolean` から `DownloadResult { success, exitCode, stderr }` に変更。yt-dlp の exit code と sanitized stderr を保持する。
  - 秘密情報(URL 内の認証情報、Cookie / Authorization ヘッダー)を stderr から scrub する `sanitizeSecrets()` を追加。
  - `getVideoMetadata()` の stderr ログにも同じ `sanitizeSecrets()` を適用。
- `downloader/src/main.ts`
  - `ParallelDownloadVideo.runDownloadVideo()` のリトライループで最新の `DownloadResult` と attempt 番号を保持し、最終失敗時に videoId / attempt / exitCode / sanitized stderr を含む `Error` を `logger.warn()` に添付して送るように変更(GlitchTip への診断情報送信は維持しつつ、直前のコミットで確立した「想定内の個別動画失敗を error レベルにしない」方針とは矛盾させない)。

## 関連ドキュメント

Spec: https://github.com/tomacheese/fetch-youtube-bgm/issues/2966#issuecomment-5307344199
Plan: https://github.com/tomacheese/fetch-youtube-bgm/issues/2966#issuecomment-5307370864

## 検証

- `yarn compile` / `yarn lint`: 成功(既存の無関係な warning 2件のみ)
- `/deep-review`(ローカル diff モード)実施済み。スコア 50 以上の指摘 4 件を修正済み。

Closes #2966
